### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/minetro/api) |
 | PHP | ![](https://badgen.net/packagist/php/minetro/api) |
-| License | ![](https://badgen.net/github/license/minetro/api) |
+| License | ![](https://badgen.net/github/license/contributte/microapi) |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

This PR updates the README to follow the archive repository template:
- Fixed license badge URL to point to contributte/microapi instead of minetro/api

The README was already in archive style format with:
- Deprecation badge with ?deprecated=1 parameter
- Disclaimer section pointing to contributte/apitte as replacement
- Composer package info table with badges
- Past tense in Development section

## Changes
- Updated license badge URL from `minetro/api` to `contributte/microapi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)